### PR TITLE
fix: ensure the ui puts the correct images with the correct labels across all platforms

### DIFF
--- a/front-end/generate-front-end.js
+++ b/front-end/generate-front-end.js
@@ -8,13 +8,12 @@ const log = require("../lib/logger").default;
 module.exports = (bucket, commitHash, opts) => {
   AWS.config.update({ region: opts.region });
   const s3 = new AWS.S3();
+
   s3.listObjects({ Bucket: bucket, Prefix: commitHash }, (err, data) => {
-    const contents = data.Contents;
-    const s3ImagesDetails = contents
-      .map(details => `${s3.endpoint.href}${bucket}/${details.Key}`)
-    // Assumes dextrose output convention
     const names = []
-    const shots = s3ImagesDetails.reduce( (collection, url) => {
+    const shots = data.Contents.reduce( (collection, details) => {
+      const url = `${s3.endpoint.href}${bucket}/${details.Key}`;
+      
       if (!url.includes(".png")) {
         return collection;
       }
@@ -31,7 +30,7 @@ module.exports = (bucket, commitHash, opts) => {
       collection[storyName][platform] = url;
 
       return collection;
-    } ,{})
+    } ,{});
 
     const templatePath = path.join(__dirname, "template.pug");
     const compileTemplate = pug.compileFile(templatePath);

--- a/front-end/generate-front-end.js
+++ b/front-end/generate-front-end.js
@@ -1,4 +1,3 @@
-
 const fs = require("fs");
 const path = require("path");
 const AWS = require("aws-sdk");

--- a/front-end/generate-front-end.js
+++ b/front-end/generate-front-end.js
@@ -1,3 +1,4 @@
+
 const fs = require("fs");
 const path = require("path");
 const AWS = require("aws-sdk");
@@ -9,24 +10,36 @@ module.exports = (bucket, commitHash, opts) => {
   const s3 = new AWS.S3();
   s3.listObjects({ Bucket: bucket, Prefix: commitHash }, (err, data) => {
     const contents = data.Contents;
-    const s3ImagesDetails = contents.map(details => {
-      return `${s3.endpoint.href}${bucket}/${details.Key}`;
-    });
+    const s3ImagesDetails = contents
+      .map(details => `${s3.endpoint.href}${bucket}/${details.Key}`)
     // Assumes dextrose output convention
-    const webShots = s3ImagesDetails.filter(file => file.includes(".web.png"));
-    const iosShots = s3ImagesDetails.filter(file => file.includes(".ios.png"));
-    const androidShots = s3ImagesDetails.filter(file => file.includes(".android.png"));
-    const shotNames = Array.from(
-      new Set(s3ImagesDetails.map(f => f.replace(/(.ios|.web|.android).png/, "")))
-    );
+    const names = []
+    const shots = s3ImagesDetails.reduce( (collection, url) => {
+      if (!url.includes(".png")) {
+        return collection;
+      }
+
+      const storyDetails = url.match(/dextrose-test\/(.*)\.(.*)\.png/);
+      const storyName = storyDetails[1];
+      const platform = storyDetails[2];
+
+      if (!collection[storyName]) {
+        names.push(storyName);
+        collection[storyName] = {};
+      }
+
+      collection[storyName][platform] = url;
+
+      return collection;
+    } ,{})
+
     const templatePath = path.join(__dirname, "template.pug");
     const compileTemplate = pug.compileFile(templatePath);
 
+
     const dextrosePresentation = compileTemplate({
-      names: shotNames,
-      ios_pics: iosShots,
-      android_pics: androidShots,
-      web_pics: webShots
+      names: names,
+      shots: shots
     });
 
     const pagePath = path.join(__dirname, "index.html");

--- a/front-end/template.pug
+++ b/front-end/template.pug
@@ -10,14 +10,14 @@ div(class='wrapper')
   each name, index in names
     h4(class='story') Story: #{name}
     div(class='abox')
-      a(class='snap' href=`${ios_pics[index]}`) 
-        img(src=ios_pics[index] class='thumbnail')
+      a(class='snap' href=`${shots[name].ios}`) 
+        img(src=shots[name].ios class='thumbnail')
       span ios
     div(class='abox')
-      a(href=`${android_pics[index]}`) 
-        img(src=android_pics[index] class='thumbnail')
+      a(href=`${shots[name].android}`) 
+        img(src=shots[name].android class='thumbnail')
       span android
     div(class='abox')
-      a(href=`${web_pics[index]}`) 
-        img(src=web_pics[index] class='thumbnail')
+      a(href=`${shots[name].web}`) 
+        img(src=shots[name].web class='thumbnail')
       span web


### PR DESCRIPTION
For your perusal: https://s3-eu-west-1.amazonaws.com/times-components-snaps/0429ca2793416cd800020cd02f5a9b0fc2b6dcaa/index.html

You can test it yourself with the following command

`dextrose generate-html --bucket your-bucket --key your-commit-hash --region eu-west-1 --upload`